### PR TITLE
Улучшение меню импорта.

### DIFF
--- a/wfe-web/src/main/java/ru/runa/common/web/Resources.java
+++ b/wfe-web/src/main/java/ru/runa/common/web/Resources.java
@@ -48,6 +48,7 @@ public class Resources {
     public static final String CLASS_PAGING_TABLE = "paging";
     public static final String CLASS_PAGING_NAVIGATION_TD = "paging-navigation";
     public static final String CLASS_PAGING_TOTAL_COUNT_TD = "paging-total-count";
+    public static final String CLASS_SYMBOL = "symbol";
     public static final String HIDDEN_ALT = "[>]";
     public static final String VISIBLE_ALT = "[v]";
     public static final String HIDDEN_IMAGE = "/images/view_setup_hidden.gif";

--- a/wfe-web/src/main/java/ru/runa/wf/web/tag/ImportDataFileTag.java
+++ b/wfe-web/src/main/java/ru/runa/wf/web/tag/ImportDataFileTag.java
@@ -2,11 +2,7 @@ package ru.runa.wf.web.tag;
 
 import org.apache.ecs.Entities;
 import org.apache.ecs.StringElement;
-import org.apache.ecs.html.Form;
-import org.apache.ecs.html.Input;
-import org.apache.ecs.html.Label;
-import org.apache.ecs.html.TD;
-import org.apache.ecs.html.Table;
+import org.apache.ecs.html.*;
 import org.tldgen.annotations.BodyContent;
 import ru.runa.common.WebResources;
 import ru.runa.common.web.HTMLUtils;
@@ -69,7 +65,13 @@ public class ImportDataFileTag extends TitledFormTag {
         Label label = new Label(ImportDataFileAction.SET_PASSWORD);
         label.addElement(new StringElement(MessagesOther.LABEL_DATAFILE_SET_PASSWORD.message(pageContext)));
         td.addElement(label);
+        td.addElement(new Span(":").setClass(Resources.CLASS_SYMBOL));
         td.addElement(Entities.NBSP);
+        Input passwordText = new Input(Input.TEXT, ImportDataFileAction.PASSWORD_VALUE_PARAM, "123");
+        passwordText.setID(ImportDataFileAction.PASSWORD_VALUE_PARAM);
+        passwordText.setStyle("width: 300px;");
+        td.addElement(passwordText);
+        td.addElement(new BR());
         Input clearPasswordInput = new Input(Input.RADIO, ImportDataFileAction.PASSWORD_PARAM, ImportDataFileAction.CLEAR_PASSWORD);
         clearPasswordInput.setID(ImportDataFileAction.CLEAR_PASSWORD);
         td.addElement(clearPasswordInput);
@@ -77,13 +79,6 @@ public class ImportDataFileTag extends TitledFormTag {
         label.addElement(new StringElement(MessagesOther.LABEL_DATAFILE_CLEAR_PASSWORD.message(pageContext)));
         td.addElement(label);
         table.addElement(HTMLUtils.createRow(MessagesOther.TITLE_DATAFILE_ACTION_PASSWORD.message(pageContext), td));
-
-        TD passInputTd = new TD();
-        Input passwordText = new Input(Input.TEXT, ImportDataFileAction.PASSWORD_VALUE_PARAM, "123");
-        passwordText.setID(ImportDataFileAction.PASSWORD_VALUE_PARAM);
-        passwordText.setStyle("width: 300px;");
-        passInputTd.addElement(passwordText);
-        table.addElement(HTMLUtils.createRow(MessagesOther.TITLE_DATAFILE_PASSWORD.message(pageContext), passInputTd));
     }
 
     private void clearPasswordForDataSourcesRow(Table table) {
@@ -95,7 +90,13 @@ public class ImportDataFileTag extends TitledFormTag {
         Label label = new Label(ImportDataFileAction.SET_PASSWORD);
         label.addElement(new StringElement(MessagesOther.LABEL_DATAFILE_SET_PASSWORD_DATA_SOURCE.message(pageContext)));
         td.addElement(label);
+        td.addElement(new Span(":").setClass(Resources.CLASS_SYMBOL));
         td.addElement(Entities.NBSP);
+        Input passwordText = new Input(Input.TEXT, ImportDataFileAction.PASSWORD_VALUE_DATA_SOURCE_PARAM, "321");
+        passwordText.setID(ImportDataFileAction.PASSWORD_VALUE_DATA_SOURCE_PARAM);
+        passwordText.setStyle("width: 300px;");
+        td.addElement(passwordText);
+        td.addElement(new BR());
         Input clearPasswordInput = new Input(Input.RADIO, ImportDataFileAction.PASSWORD_DATA_SOURCE_PARAM, ImportDataFileAction.CLEAR_PASSWORD);
         clearPasswordInput.setID(ImportDataFileAction.CLEAR_PASSWORD);
         td.addElement(clearPasswordInput);
@@ -103,12 +104,6 @@ public class ImportDataFileTag extends TitledFormTag {
         label.addElement(new StringElement(MessagesOther.LABEL_DATAFILE_CLEAR_PASSWORD_DATA_SOURCE.message(pageContext)));
         td.addElement(label);
         table.addElement(HTMLUtils.createRow(MessagesOther.TITLE_DATAFILE_ACTION_PASSWORD_DATA_SOURCE.message(pageContext), td));
-        TD passInputTd = new TD();
-        Input passwordText = new Input(Input.TEXT, ImportDataFileAction.PASSWORD_VALUE_DATA_SOURCE_PARAM, "321");
-        passwordText.setID(ImportDataFileAction.PASSWORD_VALUE_DATA_SOURCE_PARAM);
-        passwordText.setStyle("width: 300px;");
-        passInputTd.addElement(passwordText);
-        table.addElement(HTMLUtils.createRow(MessagesOther.TITLE_DATAFILE_PASSWORD_DATA_SOURCE.message(pageContext), passInputTd));
     }
 
     @Override

--- a/wfe-web/src/main/webapp/css/main.css
+++ b/wfe-web/src/main/webapp/css/main.css
@@ -300,6 +300,10 @@ tr.executor_group {
 	background-color: tomato;
 }
 
+.symbol {
+	color: #990000;
+}
+
 .checkBoxNone {
 	display: none;
 }


### PR DESCRIPTION
В ImportDataFileTag.java:
* пароль перенесен в туже строчку в которой о нём идёт речь;
* радиобатан перенесен на новую строку.

В main.css и Resources.java
* добавлен новый класс “symbol” для “:” перед инпутами.

![изображение](https://user-images.githubusercontent.com/59407764/103159492-bcbae000-47d2-11eb-9908-49227ce81559.png)
